### PR TITLE
wrong variable name in weighted voxelize call

### DIFF
--- a/ClearMap/Scripts/CellMap.py
+++ b/ClearMap/Scripts/CellMap.py
@@ -348,7 +348,7 @@ if __name__ == "__main__":
         verbose = True
       )
   
-  vox.voxelize(points, sink=ws.filename('density', postfix='intensities'), **voxelization_parameter);
+  vox.voxelize(coordinates, sink=ws.filename('density', postfix='intensities'), **voxelization_parameter);
   
   #%%
   


### PR DESCRIPTION
I'm not sure about this, but there's no "points" variable, and the result seems fair.